### PR TITLE
Add Passport information for each Pokémon

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -10,6 +10,7 @@ const Header = () => {
     return (<header className="siteHeader">
         <Link href="/"><a className="navLogo" ><img alt="PokéPassport" src={PokeLogo.src} /></a></Link>
         <nav className="headerNav">
+            <Link href="/passport"><a className="passport">Passport list</a></Link>
             <Link href="/swsh"><a className="swsh">Sword &amp; Shield</a></Link>
             <Link href="/visc"><a className="visc">Scarlet &amp; Violet</a></Link>
         </nav>

--- a/pages/[game]/[pokemon].js
+++ b/pages/[game]/[pokemon].js
@@ -107,9 +107,11 @@ export default function PokemonInfo({game, pokemon, index, notes, prevPokemon, n
         <div className={styles.pageContainer}>
             <NavigationLink game={game} pokemon={prevPokemon} direction="left" number={index-1} preferredForm={selectedRegion}/>
             <div className={styles.container}>
-                <div className={classNames(styles.iconContainer,styles[status],styles[game+"-"+status])} style={iconContainerStyles[game]}>
-                    <img className={styles.icon} alt={pokemon.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${thisPokemon.id}.png`} />
-                </div>
+                <Link href={`/passport/${pokemon.id}${!isOriginal?`?region=${selectedRegion}`:""}`}>
+                    <a title="Check this Pokémon's passport." className={classNames(styles.iconContainer,styles[status],styles[game+"-"+status])} style={iconContainerStyles[game]}>
+                        <img className={styles.icon} alt={pokemon.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${thisPokemon.id}.png`} />
+                    </a>
+                </Link>
                 <h1 className={styles.name}>#{addTrailingZeroes(index, 3)} {thisPokemon.name}</h1>
                 <div className={styles.forms}>{forms}</div>
                 <div className={classNames(styles.status,styles[status],styles[game+"-"+status])}>{labels[game][status] || "Invalid tag"}</div>

--- a/pages/passport/[pokemon].js
+++ b/pages/passport/[pokemon].js
@@ -12,6 +12,12 @@ const latestGame = "visc";
 
 const regionRegExp = /(alola|galar|hisui)/;
 
+const imageAliases = {
+    hisui: {
+        550: "basculin-white-striped"
+    }
+}
+
 export default function PokemonPassport({pokemonData, prevPokemon, nextPokemon, pokemonNumber}) {
     const [selectedRegion, setSelectedRegion] = useReducer(() => {
         const query = new URLSearchParams(window.location.search);
@@ -88,9 +94,10 @@ export default function PokemonPassport({pokemonData, prevPokemon, nextPokemon, 
 
     const forms = pokemonData[latestGame].forms?.map(form => {
         const formName = regionRegExp.exec(form.id)[1] // No need for validation. The regexp should always match.
+        const hasSubstituteImage = imageAliases[formName]!=null && imageAliases[formName][pokemonNumber]!=null;
         if(formName===selectedRegion) return;
         return (<div className={classNames(styles.formLink,passportStyles.default)} key={form.id}>
-            <Link href={`/passport/${pokemonData[latestGame].id}?region=${formName}`}><a title={`${formNames[formName]} form`}><img alt={form.id} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${form.id}.png`}/></a></Link>
+            <Link href={`/passport/${pokemonData[latestGame].id}?region=${formName}`}><a title={`${formNames[formName]} form`}><img alt={form.id} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${hasSubstituteImage? imageAliases[formName][pokemonNumber] : form.id}.png`}/></a></Link>
         </div>)
     })
 
@@ -99,6 +106,8 @@ export default function PokemonPassport({pokemonData, prevPokemon, nextPokemon, 
             <Link href={`/passport/${pokemonData[latestGame].id}`}><a title="Original form"><img alt={pokemonData[latestGame].id} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${pokemonData[latestGame].id}.png`}/></a></Link>
         </div>)
     }
+
+    const hasSubstituteImage = imageAliases[selectedRegion]!=null && imageAliases[selectedRegion][pokemonNumber]!=null;
 
     return (<div>
         <center>
@@ -113,7 +122,7 @@ export default function PokemonPassport({pokemonData, prevPokemon, nextPokemon, 
             <NavigationLink pokemon={prevPokemon} direction="left" number={pokemonNumber-1} preferredForm={selectedRegion}/>
             <div className={passportStyles.container}>
                 <div className={classNames(styles.iconContainer, passportStyles.default)} style={{backgroundImage: `url("/poke-passport/logo-${regionShortForm[selectedRegion]?.id || regionShortForm.original.id}.svg")`, backgroundSize: regionShortForm[selectedRegion]?.size || regionShortForm.original.size, backgroundBlendMode: "multiply"}}>
-                    <img className={styles.icon} alt={pokemonData.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${isOriginal? pokemonData[latestGame].id : thisPokemon.id}.png`} />
+                    <img className={styles.icon} alt={pokemonData.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${isOriginal? pokemonData[latestGame].id : (hasSubstituteImage? imageAliases[selectedRegion][pokemonNumber] : thisPokemon.id)}.png`} />
                 </div>
                 <h1 className={styles.name}>#{addTrailingZeroes(pokemonNumber, 3)} {pokemonData[latestGame].name}</h1>
                 <div className={styles.forms}>{forms}</div>
@@ -242,6 +251,8 @@ function NavigationLink({pokemon, number, direction, preferredForm}) {
 
     const isOriginal = preferredForm==null || preferredForm==="original";
 
+    const hasSubstituteImage = imageAliases[preferredForm]!=null && imageAliases[preferredForm][number]!=null;
+
     if(pokemon!=null) {
         let thisPokemon = {...pokemon};
         let form = "original";
@@ -259,7 +270,7 @@ function NavigationLink({pokemon, number, direction, preferredForm}) {
         return (<Link href={`/passport/${pokemon.id}${form!=="original"?`?region=${form}`:""}`} passHref>
             <a className={styles.navPokemon}>
                 <div>
-                    <img alt={thisPokemon.name} className={classNames(styles.navIcon, passportStyles.default)} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${thisPokemon.id}.png`}/>
+                    <img alt={thisPokemon.name} className={classNames(styles.navIcon, passportStyles.default)} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${hasSubstituteImage? imageAliases[preferredForm][number] : thisPokemon.id}.png`}/>
                     <div>{directions[direction]} #{number} {thisPokemon.name}</div>
                 </div>
             </a>

--- a/pages/passport/[pokemon].js
+++ b/pages/passport/[pokemon].js
@@ -149,9 +149,11 @@ function TransferabilityTable({pokemon, labels, index}) {
         }
         const regionRegExp = new RegExp(`-${region}$`);
         if(pokemon[label]) {
+            const isOriginal = region==="original" || !pokemon[label].forms?.find(form => regionRegExp.test(form.id));
+            const pokeStatus = !isOriginal && pokemon[label].forms? pokemon[label].forms.find(form => regionRegExp.test(form.id)).status : pokemon[label].status;
             const defaultLabel = (<Link key={label} href={`/${label}/${pokemon[latestGame].id}${isOriginal?"":`?region=${region}`}`}>
-                <a className={classNames(passportStyles.gridRow,passportStyles[pokemon[label].status],passportStyles[label+"-"+(pokemon[label].status)])}>
-                    {status[labels[label][pokemon[label].status]]}
+                <a className={classNames(passportStyles.gridRow,passportStyles[pokeStatus],passportStyles[label+"-"+pokeStatus])}>
+                    {status[labels[label][pokeStatus]]}
                 </a>
             </Link>)
             if(label === "swsh") {
@@ -196,8 +198,11 @@ function TransferabilityTable({pokemon, labels, index}) {
                     return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-crown"])}>{status.Native}</div>
                 else
                     return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>{status["N/A"]}</div>
-            } else if(label === "arceus" && index >= 899 && index < 906) {
-                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["confirmed"])}>{status.Native}</div>
+            } else if(label === "arceus") {
+                if((index >= 899 && index < 906) || pokemon[latestGame].forms?.find(variant => /-hisui$/.test(variant.id)))
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["confirmed"])}>{status.Native}</div>
+                else
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>{status["N/A"]}</div>
             } else {
                 return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>{status["N/A"]}</div>
             }

--- a/pages/passport/[pokemon].js
+++ b/pages/passport/[pokemon].js
@@ -1,0 +1,187 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import classNames from 'classnames';
+
+import { addTrailingZeroes } from "../../util.ts";
+
+import styles from "../../styles/PokemonInfo.module.css";
+import passportStyles from "../../styles/Passport.module.css";
+
+const latestGame = "visc";
+
+export default function PokemonPassport({pokemonData, prevPokemon, nextPokemon, pokemonNumber}) {
+    let thisPokemon = {...pokemonData};
+
+    const transferability = {
+        swsh: {
+            base: "Yes",
+            armor: "Yes",
+            crown: "Yes",
+            other: "Yes",
+            no: "No"
+        },
+        arceus: "N/A",
+        bdsp: "N/A",
+        visc: {
+            confirmed: "Yes",
+            guaranteed: "Yes",
+            possible: "Unknown",
+            no: "No",
+            unknown: "Unknown"
+        }
+    }
+
+    const passportPower = Object.keys(pokemonData).reduce((acc, game) => {
+        const labels = transferability[game];
+        if(game === "arceus" || game === "bdsp")
+            return acc;
+        return labels[pokemonData[game]?.status] === "Yes" ? acc + 1 : acc;
+    }, 0);
+
+    return (<div>
+        <center>
+            <h1>{pokemonData[latestGame].name}&apos;s Passport</h1>
+            <Link href={`/passport`}><a>↑ Back to list</a></Link>
+        </center>
+        <Head>
+            <title>Passport for {thisPokemon[latestGame].name} - PokéPassport</title>
+            <meta name="description" content={`Check which games ${thisPokemon.name} can be transfered to.`} />
+        </Head>
+        <div className={styles.pageContainer}>
+            <NavigationLink pokemon={prevPokemon} direction="left" number={pokemonNumber-1} />
+            <div className={passportStyles.container}>
+                <div className={classNames(styles.iconContainer, passportStyles.default)} style={{backgroundImage: `url("/poke-passport/logo-visc.svg")`, backgroundSize: "90px", backgroundBlendMode: "multiply"}}>
+                    <img className={styles.icon} alt={pokemonData.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${thisPokemon[latestGame].id}.png`} />
+                </div>
+                <h1 className={styles.name}>#{addTrailingZeroes(pokemonNumber, 3)} {thisPokemon[latestGame].name}</h1>
+                <div className={passportStyles.label}>Passport Power<sup><abbr title="A rating based on how many games this Pokémon can be transfered to, excluding the games where a Pokémon first originated from.">(?)</abbr></sup>: {passportPower}</div>
+                <div className={passportStyles.separator}>Transferability</div>
+                <TransferabilityTable pokemon={thisPokemon} index={pokemonNumber} labels={transferability} />
+            </div>
+            <NavigationLink pokemon={nextPokemon} direction="right" number={pokemonNumber+1} />
+        </div>
+    </div>)
+}
+
+function TransferabilityTable({pokemon, labels, index}) {
+    const headings = Object.keys(labels).map(label => {
+        const labels = {
+            swsh: "SwSh",
+            arceus: "L:A",
+            bdsp: "BDSP",
+            visc: "ScVi"
+        }
+        const longLabels = {
+            swsh: "Sword & Shield",
+            arceus: "Legends: Arceus",
+            bdsp: "Brilliant Diamond & Shining Pearl",
+            visc: "Scarlet & Violet"
+        }
+        return <div key={label} title={longLabels[label]} className={classNames(passportStyles.gridLabel, passportStyles[label])}>{labels[label]}</div>
+    })
+    const rows = Object.keys(labels).map(label => {
+        const status = {
+            Yes: <span><b>✓</b> Yes</span>,
+            No: <span><b>✗</b> No</span>,
+            Unknown: <span><b>?</b> Unknown</span>,
+            "N/A": "N/A"
+        }
+        if(pokemon[label]) {
+            return (<Link key={label} href={`/${label}/${pokemon[latestGame].id}`}>
+                <a className={classNames(passportStyles.gridRow,passportStyles[pokemon[label].status],passportStyles[label+"-"+(pokemon[label].status)])}>
+                    {status[labels[label][pokemon[label].status]]}
+                </a>
+            </Link>);
+        } else {
+            if(label === "swsh") {
+                if(index >= 810 && index < 891)
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-base"])}><span><b>✓</b> Native</span></div>
+                else if (index >= 891 && index < 894)
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-armor"])}><span><b>✓</b> Native</span></div>
+                else if (index >= 894 && index < 899)
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-crown"])}><span><b>✓</b> Native</span></div>
+                else
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>N/A</div>
+            } else if(label === "arceus" && index >= 899 && index < 906) {
+                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["confirmed"])}><span><b>✓</b> Native</span></div>
+            } else {
+                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>N/A</div>
+            }
+        }
+        
+    });
+    return (
+        <div className={passportStyles.transferGrid}>
+            {headings}
+            {rows}
+        </div>
+    )
+}
+
+function NavigationLink({pokemon, number, direction}) {
+    const directions = {
+        left: "←",
+        right: "→",
+    };
+    const limits = {
+        left: "First Pokémon",
+        right: "Last Pokémon"
+    }
+    if(pokemon!=null) {
+        let thisPokemon = {...pokemon};
+        return (<Link href={`/passport/${pokemon.id}`} passHref>
+            <a className={styles.navPokemon}>
+                <div>
+                    <img alt={thisPokemon.name} className={classNames(styles.navIcon, passportStyles.default)} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${thisPokemon.id}.png`}/>
+                    <div>{directions[direction]} #{number} {thisPokemon.name}</div>
+                </div>
+            </a>
+        </Link>)
+    } else {
+        return (
+            <div className={styles.navPokemon}>
+                <img alt="Unknown" className={classNames(styles.navIcon,styles.unknown)} style={{width:"68px", height:"56px"}} src="https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/unknown.png"/>
+                <div>{directions[direction]} {limits[direction]}</div>
+            </div>
+        )
+    }
+}
+
+export async function getStaticProps({params}) {
+    const {pokemon} = params;
+
+    const allPokemonData = {
+        swsh: (await import ("../../data/swsh.json")).default,
+        visc: (await import ("../../data/visc.json")).default,
+    }
+
+    const pokemonData = {
+        swsh: allPokemonData.swsh.filter(poke => poke.id === pokemon)[0] || null,
+        visc: allPokemonData.visc.filter(poke => poke.id === pokemon)[0] || null,
+    };
+    const pokemonNumber = allPokemonData[latestGame].indexOf(pokemonData[latestGame]) +1;
+
+    const prevPokemon = allPokemonData[latestGame][allPokemonData[latestGame].indexOf(pokemonData[latestGame]) - 1] || null;
+    const nextPokemon = allPokemonData[latestGame][allPokemonData[latestGame].indexOf(pokemonData[latestGame]) + 1] || null;
+    
+    return {
+        props: {
+            pokemonData,
+            prevPokemon,
+            nextPokemon,
+            pokemonNumber
+        }
+    }
+}
+
+export async function getStaticPaths() {
+    // The list has to be updated manually to use the latest Pokémon games released.
+    const pokemonList = (await import ("../../data/visc.json")).default;
+
+    const pokemon = pokemonList.map(poke => ({ params: {pokemon: poke.id } }))
+
+    return {
+        paths: pokemon,
+        fallback: false
+    }
+}

--- a/pages/passport/[pokemon].js
+++ b/pages/passport/[pokemon].js
@@ -1,3 +1,4 @@
+import { useReducer, useEffect } from 'react';
 import Head from 'next/head'
 import Link from 'next/link'
 import classNames from 'classnames';
@@ -9,8 +10,40 @@ import passportStyles from "../../styles/Passport.module.css";
 
 const latestGame = "visc";
 
+const regionRegExp = /(alola|galar|hisui)/;
+
 export default function PokemonPassport({pokemonData, prevPokemon, nextPokemon, pokemonNumber}) {
-    let thisPokemon = {...pokemonData};
+    const [selectedRegion, setSelectedRegion] = useReducer(() => {
+        const query = new URLSearchParams(window.location.search);
+        const region = query.get("region");
+        return regionRegExp.test(region)? region : "original";
+    }, "original");
+
+    useEffect(() => {
+        setSelectedRegion();
+    });
+
+    const isOriginal = selectedRegion == null || selectedRegion === "original";
+
+    let thisPokemon = !isOriginal && pokemonData[latestGame].forms!=null ? pokemonData[latestGame].forms.find(variant => {
+        const regexp = new RegExp(`-${selectedRegion}$`);
+        return regexp.test(variant.id);
+    })  : pokemonData;
+
+    if(thisPokemon==null) { thisPokemon = pokemonData; }
+
+    const formNames = {
+        "original": "Original",
+        "alola": "Alolan",
+        "galar": "Galarian",
+        "hisui": "Hisuian",
+    }
+    const regionShortForm = {
+        galar: {id: "swsh", size:"80px"},
+        alola: {id: "alola", size:"90px"},
+        original: {id: "visc", size:"90px"},
+        hisui: {id: "arceus", size:"90px"}
+    }
 
     const transferability = {
         swsh: {
@@ -38,32 +71,59 @@ export default function PokemonPassport({pokemonData, prevPokemon, nextPokemon, 
         return labels[pokemonData[game]?.status] === "Yes" ? acc + 1 : acc;
     }, 0);
 
+    const forms = pokemonData[latestGame].forms?.map(form => {
+        const formName = regionRegExp.exec(form.id)[1] // No need for validation. The regexp should always match.
+        if(formName===selectedRegion) return;
+        return (<div className={classNames(styles.formLink,passportStyles.default)} key={form.id}>
+            <Link href={`/passport/${pokemonData[latestGame].id}?region=${formName}`}><a title={`${formNames[formName]} form`}><img alt={form.id} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${form.id}.png`}/></a></Link>
+        </div>)
+    })
+
+    if(forms!=null && !isOriginal) {
+        forms.unshift(<div className={classNames(styles.formLink,passportStyles.default)} key={pokemonData[latestGame].id}>
+            <Link href={`/passport/${pokemonData[latestGame].id}`}><a title="Original form"><img alt={pokemonData[latestGame].id} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${pokemonData[latestGame].id}.png`}/></a></Link>
+        </div>)
+    }
+
     return (<div>
         <center>
             <h1>{pokemonData[latestGame].name}&apos;s Passport</h1>
-            <Link href={`/passport`}><a>↑ Back to list</a></Link>
+            <Link href={`/passport${!isOriginal?`?region=${selectedRegion}`:""}`}><a>↑ Back to list</a></Link>
         </center>
         <Head>
-            <title>Passport for {thisPokemon[latestGame].name} - PokéPassport</title>
-            <meta name="description" content={`Check which games ${thisPokemon.name} can be transfered to.`} />
+            <title>Passport for {pokemonData[latestGame].name} - PokéPassport</title>
+            <meta name="description" content={`Check which games ${pokemonData[latestGame].name} can be transfered to.`} />
         </Head>
         <div className={styles.pageContainer}>
-            <NavigationLink pokemon={prevPokemon} direction="left" number={pokemonNumber-1} />
+            <NavigationLink pokemon={prevPokemon} direction="left" number={pokemonNumber-1} preferredForm={selectedRegion}/>
             <div className={passportStyles.container}>
-                <div className={classNames(styles.iconContainer, passportStyles.default)} style={{backgroundImage: `url("/poke-passport/logo-visc.svg")`, backgroundSize: "90px", backgroundBlendMode: "multiply"}}>
-                    <img className={styles.icon} alt={pokemonData.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${thisPokemon[latestGame].id}.png`} />
+                <div className={classNames(styles.iconContainer, passportStyles.default)} style={{backgroundImage: `url("/poke-passport/logo-${regionShortForm[selectedRegion]?.id || regionShortForm.original.id}.svg")`, backgroundSize: regionShortForm[selectedRegion]?.size || regionShortForm.original.size, backgroundBlendMode: "multiply"}}>
+                    <img className={styles.icon} alt={pokemonData.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${isOriginal? pokemonData[latestGame].id : thisPokemon.id}.png`} />
                 </div>
-                <h1 className={styles.name}>#{addTrailingZeroes(pokemonNumber, 3)} {thisPokemon[latestGame].name}</h1>
+                <h1 className={styles.name}>#{addTrailingZeroes(pokemonNumber, 3)} {pokemonData[latestGame].name}</h1>
+                <div className={styles.forms}>{forms}</div>
                 <div className={passportStyles.label}>Passport Power<sup><abbr title="A rating based on how many games this Pokémon can be transfered to, excluding the games where a Pokémon first originated from.">(?)</abbr></sup>: {passportPower}</div>
                 <div className={passportStyles.separator}>Transferability</div>
-                <TransferabilityTable pokemon={thisPokemon} index={pokemonNumber} labels={transferability} />
+                <TransferabilityTable pokemon={pokemonData} index={pokemonNumber} labels={transferability} />
             </div>
-            <NavigationLink pokemon={nextPokemon} direction="right" number={pokemonNumber+1} />
+            <NavigationLink pokemon={nextPokemon} direction="right" number={pokemonNumber+1} preferredForm={selectedRegion}/>
         </div>
     </div>)
 }
 
 function TransferabilityTable({pokemon, labels, index}) {
+    const [region, setSelectedRegion] = useReducer(() => {
+        const query = new URLSearchParams(window.location.search);
+        const region = query.get("region");
+        return regionRegExp.test(region)? region : "original";
+    }, "original");
+
+    useEffect(() => {
+        setSelectedRegion();
+    });
+
+    const isOriginal = region == null || region === "original";
+
     const headings = Object.keys(labels).map(label => {
         const labels = {
             swsh: "SwSh",
@@ -84,28 +144,62 @@ function TransferabilityTable({pokemon, labels, index}) {
             Yes: <span><b>✓</b> Yes</span>,
             No: <span><b>✗</b> No</span>,
             Unknown: <span><b>?</b> Unknown</span>,
+            Native: <span><b>✓</b> Native</span>,
             "N/A": "N/A"
         }
+        const regionRegExp = new RegExp(`-${region}$`);
         if(pokemon[label]) {
-            return (<Link key={label} href={`/${label}/${pokemon[latestGame].id}`}>
+            const defaultLabel = (<Link key={label} href={`/${label}/${pokemon[latestGame].id}${isOriginal?"":`?region=${region}`}`}>
                 <a className={classNames(passportStyles.gridRow,passportStyles[pokemon[label].status],passportStyles[label+"-"+(pokemon[label].status)])}>
                     {status[labels[label][pokemon[label].status]]}
                 </a>
-            </Link>);
+            </Link>)
+            if(label === "swsh") {
+                if(region === "original") {
+                    return defaultLabel;
+                } else {
+                    if(pokemon[latestGame].forms?.find(variant => regionRegExp.test(variant.id))) {
+                        if(region === "galar") {
+                            // Galarian Slowpoke was introduced in 1.1.0, and is classified as "Other" in this listing.
+                            if (index === 79)
+                                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-other"])}>{status.Native}</div>
+                            // Galarian Slowbro was introduced in Isle of Armor.
+                            if (index === 80)
+                                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-armor"])}>{status.Native}</div>
+                            // Galarian Articuno, Zapdos, Moltres and Slowking were introduced in Crown Tundra.
+                            else if((index >= 144 && index < 147) || index === 199)
+                                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-crown"])}>{status.Native}</div>
+                            else
+                                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-base"])}>{status.Native}</div>
+                        } else if(region === "alola") {
+                            if(pokemon.status === "no")
+                                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["no"])}>{status.No}</div> 
+                            else
+                                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-crown"])}>{status.Yes}</div>
+                        } else {
+                            return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>{status["N/A"]}</div>;
+                        }
+                    } else {
+                        return defaultLabel;
+                    }
+                }
+            } else if(label === "visc") {
+                return defaultLabel;
+            }
         } else {
             if(label === "swsh") {
                 if(index >= 810 && index < 891)
-                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-base"])}><span><b>✓</b> Native</span></div>
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-base"])}>{status.Native}</div>
                 else if (index >= 891 && index < 894)
-                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-armor"])}><span><b>✓</b> Native</span></div>
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-armor"])}>{status.Native}</div>
                 else if (index >= 894 && index < 899)
-                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-crown"])}><span><b>✓</b> Native</span></div>
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["swsh-crown"])}>{status.Native}</div>
                 else
-                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>N/A</div>
+                    return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>{status["N/A"]}</div>
             } else if(label === "arceus" && index >= 899 && index < 906) {
-                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["confirmed"])}><span><b>✓</b> Native</span></div>
+                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["confirmed"])}>{status.Native}</div>
             } else {
-                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>N/A</div>
+                return <div key={label} className={classNames(passportStyles.gridRow,passportStyles["not-available"])}>{status["N/A"]}</div>
             }
         }
         
@@ -118,7 +212,7 @@ function TransferabilityTable({pokemon, labels, index}) {
     )
 }
 
-function NavigationLink({pokemon, number, direction}) {
+function NavigationLink({pokemon, number, direction, preferredForm}) {
     const directions = {
         left: "←",
         right: "→",
@@ -127,9 +221,24 @@ function NavigationLink({pokemon, number, direction}) {
         left: "First Pokémon",
         right: "Last Pokémon"
     }
+
+    const isOriginal = preferredForm==null || preferredForm==="original";
+
     if(pokemon!=null) {
         let thisPokemon = {...pokemon};
-        return (<Link href={`/passport/${pokemon.id}`} passHref>
+        let form = "original";
+        if(!isOriginal && pokemon.forms?.length > 0) {
+            thisPokemon = pokemon.forms.find(form => {
+                const formTest = new RegExp(`-(?:${preferredForm})`); 
+                return formTest.test(form.id);
+            });
+            if(thisPokemon)
+                form = preferredForm;
+            else
+                // Since we're not reassigning thisPokemon, we don't have to clone here.
+                thisPokemon = pokemon;
+        }
+        return (<Link href={`/passport/${pokemon.id}${form!=="original"?`?region=${form}`:""}`} passHref>
             <a className={styles.navPokemon}>
                 <div>
                     <img alt={thisPokemon.name} className={classNames(styles.navIcon, passportStyles.default)} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${thisPokemon.id}.png`}/>

--- a/pages/passport/[pokemon].js
+++ b/pages/passport/[pokemon].js
@@ -145,7 +145,7 @@ function TransferabilityTable({pokemon, labels, index}) {
             No: <span><b>✗</b> No</span>,
             Unknown: <span><b>?</b> Unknown</span>,
             Native: <span><b>✓</b> Native</span>,
-            "N/A": "N/A"
+            "N/A": <span>No info</span>
         }
         const regionRegExp = new RegExp(`-${region}$`);
         if(pokemon[label]) {

--- a/pages/passport/index.js
+++ b/pages/passport/index.js
@@ -14,6 +14,12 @@ const getRegion = () => {
 
 const regionRegExp = /(alola|galar|hisui)/;
 
+const imageAliases = {
+    hisui: {
+        550: "basculin-white-striped"
+    }
+}
+
 export default function PassportsTable({ pokemonList }) {
     const [selectedRegion, setSelectedRegion] = useReducer(() => getRegion(),"original");
     useEffect(() => {
@@ -45,10 +51,14 @@ export default function PassportsTable({ pokemonList }) {
                 shortenedId = pokemon.id.replace("-"+region, '');
         }
 
+        const number = pokeList.indexOf(pokemon)+1;
+
+        const hasSubstituteImage = imageAliases[region]!=null && imageAliases[region][number]!=null;
+
         return <Link key={pokemon.id} href={`/passport/${shortenedId}${region!=="original"?`?region=${region}`:""}`}>
             <a><div className={tableStyles.tableEntry} style={{backgroundColor: "#f5f1dc"}}>
-                <span className={tableStyles.tableEntryNumber}>{addTrailingZeroes(pokeList.indexOf(pokemon)+1, 3)}</span>
-                <img alt={pokemon.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${pokemon.id}.png`}/>
+                <span className={tableStyles.tableEntryNumber}>{addTrailingZeroes(number, 3)}</span>
+                <img alt={pokemon.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${hasSubstituteImage? imageAliases[region][number] : pokemon.id}.png`}/>
                 </div></a>
         </Link>
     });

--- a/pages/passport/index.js
+++ b/pages/passport/index.js
@@ -1,18 +1,53 @@
+import { useReducer, useEffect } from 'react';
 import Head from 'next/head'
 import Link from 'next/link'
-import classNames from 'classnames';
 
 import { addTrailingZeroes } from "../../util.ts";
 
 import tableStyles from "../../styles/Table.module.css";
 
-export default function PassportsTable({ pokemonList }) {
+const getRegion = () => {
+    const query = new URLSearchParams(window.location.search);
+    const region = query.get("region");
+    return regionRegExp.test(region)? region : "original";
+}
 
-    const tableCells = pokemonList.map(pokemon => { 
-        const shortenedId = pokemon.id;
-        return <Link key={pokemon.id} href={`/passport/${shortenedId}`}>
+const regionRegExp = /(alola|galar|hisui)/;
+
+export default function PassportsTable({ pokemonList }) {
+    const [selectedRegion, setSelectedRegion] = useReducer(() => getRegion(),"original");
+    useEffect(() => {
+        setSelectedRegion();
+    });
+
+    // Clone pokemonList to avoid mutating the original
+    const pokeList = [...pokemonList];
+    const pokemonWithForms = pokeList.filter(pokemon => pokemon.forms != null)
+
+    if(selectedRegion !== "original") {
+        for(const pokemonId in pokemonWithForms) {
+            const pokemon = pokemonWithForms[pokemonId];
+            const form = pokemon.forms.find(form => new RegExp(`-(?:${selectedRegion})`).test(form.id));
+            if(form != null) {
+                const originalPoke = pokemonList.find(poke => poke.id === pokemon.id);
+                pokeList[pokemonList.indexOf(originalPoke)] = form;
+            }
+        }
+    }
+
+    const tableCells = pokeList.map(pokemon => { 
+        let region = "original", shortenedId = pokemon.id;
+
+        if(regionRegExp) {
+            const test = regionRegExp.exec(pokemon.id);
+            region = test? test[1] : "original";
+            if(region!=="original")
+                shortenedId = pokemon.id.replace("-"+region, '');
+        }
+
+        return <Link key={pokemon.id} href={`/passport/${shortenedId}${region!=="original"?`?region=${region}`:""}`}>
             <a><div className={tableStyles.tableEntry} style={{backgroundColor: "#f5f1dc"}}>
-                <span className={tableStyles.tableEntryNumber}>{addTrailingZeroes(pokemonList.indexOf(pokemon)+1, 3)}</span>
+                <span className={tableStyles.tableEntryNumber}>{addTrailingZeroes(pokeList.indexOf(pokemon)+1, 3)}</span>
                 <img alt={pokemon.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${pokemon.id}.png`}/>
                 </div></a>
         </Link>
@@ -27,12 +62,40 @@ export default function PassportsTable({ pokemonList }) {
                 <h1>Explore Pokémon passports</h1>
                 <p>Here is the list of all Pokémon from all currently released generations.<br/>
                 You may check their individual passports by clicking on their entry.</p>
-                <p>Currently, regional forms are not shown in each Pokémon&apos;s passport.</p>
+                <p>You can switch between regional forms by clicking one of the regional emblems below.</p>
+                <RegionSelector/>
             </center>
         <div className={tableStyles.table}>
             {tableCells}
         </div>
     </div>)
+}
+
+function RegionSelector() {
+    const regions = [
+        {id: "original", label: "Original regions"},
+        {id: "alola", label: "Alola"},
+        {id: "galar", label: "Galar"},
+        {id: "hisui", label: "Hisui"},
+    ];
+    const images = {
+        original: "/poke-passport/logo-visc.svg",
+        alola: "/poke-passport/logo-alola.svg",
+        galar: "/poke-passport/logo-swsh.svg",
+        hisui: "/poke-passport/logo-arceus.svg"
+    }
+    return (
+        <nav className={tableStyles.regionNavigator}>
+            {regions.map(region => (
+                <Link key={region.id} href={`/passport/?region=${region.id}`} passHref>
+                    <div className={tableStyles.regionSelector}>
+                        <img alt={region.label} src={images[region.id]}/>
+                        <a>{region.label}</a>
+                    </div>
+                </Link>
+            ))}
+        </nav>
+    );
 }
 
 export async function getStaticProps() {

--- a/pages/passport/index.js
+++ b/pages/passport/index.js
@@ -1,0 +1,47 @@
+import Head from 'next/head'
+import Link from 'next/link'
+import classNames from 'classnames';
+
+import { addTrailingZeroes } from "../../util.ts";
+
+import tableStyles from "../../styles/Table.module.css";
+
+export default function PassportsTable({ pokemonList }) {
+
+    const tableCells = pokemonList.map(pokemon => { 
+        const shortenedId = pokemon.id;
+        return <Link key={pokemon.id} href={`/passport/${shortenedId}`}>
+            <a><div className={tableStyles.tableEntry} style={{backgroundColor: "#f5f1dc"}}>
+                <span className={tableStyles.tableEntryNumber}>{addTrailingZeroes(pokemonList.indexOf(pokemon)+1, 3)}</span>
+                <img alt={pokemon.name} src={`https://raw.githubusercontent.com/msikma/pokesprite/master/pokemon-gen8/regular/${pokemon.id}.png`}/>
+                </div></a>
+        </Link>
+    });
+
+    return (<div>
+        <Head>
+            <title>PokéPassport - Explore Pokémon</title>
+            <meta name="description" content="Explore all Pokémon's transferability to modern Pokémon games." />
+        </Head>
+        <center>
+                <h1>Explore Pokémon passports</h1>
+                <p>Here is the list of all Pokémon from all currently released generations.<br/>
+                You may check their individual passports by clicking on their entry.</p>
+                <p>Currently, regional forms are not shown in each Pokémon&apos;s passport.</p>
+            </center>
+        <div className={tableStyles.table}>
+            {tableCells}
+        </div>
+    </div>)
+}
+
+export async function getStaticProps() {
+
+    // The list has to be updated manually to use the latest Pokémon games released.
+    const pokemonList = (await import ("../../data/visc.json")).default;
+    return {
+        props: {
+            pokemonList
+        },
+    }
+}

--- a/styles/Passport.module.css
+++ b/styles/Passport.module.css
@@ -1,0 +1,163 @@
+.container {
+    position: relative;
+    width: 60%;
+    min-width: 550px;
+    max-width: 1000px;
+    margin: 0 auto;
+    top: 25px;
+    border-radius: 20px;
+    border: 2px solid gray;
+    overflow: hidden;
+    display: grid;
+    box-sizing: border-box;
+    grid-template-columns: 136px auto auto 10em;
+    grid-template-areas:
+        "icon name name forms"
+        "icon passport passport forms"
+        "separator separator separator separator"
+        "notes notes notes notes";
+}
+
+.container h1, .container h2, .container h3 {
+    margin: 0.5em 0;
+}
+
+.label {
+    grid-area: passport;
+    font-weight: 450;
+    padding: 0.25rem 0.75rem;
+    font-size: 1.333rem;
+}
+
+.label abbr {
+    font-size: 8pt;
+    cursor: help;
+}
+
+.separator {
+    grid-area: separator;
+    border: 2px solid gray;
+    border-left: none;
+    border-right: none;
+    background-color: silver;
+    padding: 0.1em 0;
+    font-size: 16pt;
+    font-weight: bold;
+    text-align: center;
+}
+
+.transferGrid {
+    grid-area: notes;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+}
+
+.gridLabel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 14pt;
+    padding: 0.5em 0;
+    border-left: 1px solid gray;
+    border-right: 1px solid gray;
+    cursor: help;
+}
+
+.gridLabel:nth-child(4n+1), .gridRow:nth-child(4n+1) {
+    border-left: none;
+}
+.gridLabel:nth-child(4n+4), .gridRow:nth-child(4n+4) {
+    border-right: none;
+}
+
+.gridLabel.swsh {
+    background: rgb(254,17,152);
+    background: linear-gradient(118deg, #fe1198 0%, #35b7ff 100%);
+    color: white;
+}
+
+.gridLabel.visc {
+    background: #ce3226;
+    background: linear-gradient(118deg, #ff3b2d 0%, #801fb8 100%);
+    color: #ffe555;
+}
+
+.gridLabel.bdsp {
+    background: #f5a1c2;
+    background: linear-gradient(118deg, #19befe 0%, #f5a1c2 100%);
+    color: white;
+}
+
+.gridLabel.arceus {
+    background: #009bdb;
+    background: linear-gradient(118deg, #009bdb 0%, #72be8e 100%);
+    color: #221815;
+}
+
+.gridRow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5em 0;
+    transition: none;
+    border-top: 2px solid gray;
+    border-left: 1px solid gray;
+    border-right: 1px solid gray;
+}
+
+.default {
+    background-color: rgb(245, 241, 220);
+}
+
+.unknown {
+    background-color: #aaa;
+    color: black!important;
+}
+
+.confirmed {
+    background-color: lime;
+    color: black!important;
+}
+
+.guaranteed {
+    background-color: blue;
+    color: white!important;
+}
+
+.possible {
+    background-color: yellow;
+    color: black!important;
+}
+
+.not-available {
+    background-color: #333;
+    cursor: not-allowed;
+    color: white!important;
+}
+
+.no {
+    background-color: red;
+    color: black!important;
+}
+
+/** GAME SPECIFIC **/
+/* Sword & Shield */
+.swsh-base {
+    background-color: #22acff;
+    color: black!important;
+}
+.swsh-armor {
+    background-color: #dfdf41;
+    color: black!important;
+}
+
+.swsh-crown {
+    background-color: #2bb673;
+    color: black!important;
+}
+
+.swsh-other {
+    background-color: #ff2a6e;
+    color: black!important;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -79,17 +79,24 @@ nav.sideNav a {
   width: 10em;
   text-align: center;
 }
-.siteHeader > nav.headerNav > .swsh {
+
+.siteHeader > nav.headerNav > a {
   border-radius: 1em;
-  /* border-color: #38446b; */
+}
+
+.siteHeader > nav.headerNav > .swsh {
   background: rgb(254,17,152);
   background: linear-gradient(118deg, #fe1198 0%, #35b7ff 100%);
 }
 .siteHeader > nav.headerNav > .visc {
-  border-radius: 1em;
   border-color: #ffe555;
   background: #ce3226;
   background: linear-gradient(118deg, #ff3b2d 0%, #801fb8 100%);
+}
+.siteHeader > nav.headerNav > .passport {
+  border-color: rgb(229 164 175);
+  background: rgb(195,150,35);
+  background: linear-gradient(118deg, rgba(195,150,35,1) 0%, rgba(135,86,0,1) 100%);
 }
 
 footer {


### PR DESCRIPTION
This adds a Passport section to the website, which contains a list of entries for each Pokémon.
Each entry contains an overview of which games a Pokémon (and their respective regional forms) can be transferred to, and includes a "Passport Power" score that tallies the games that can be transferred to and said Pokémon (and forms) is not native (aka first introduced) to.

### Checklist
- [X] Add Passport page
- [X] Add individual Pokémon Passport pages.
- [X] Add support for regional variants.